### PR TITLE
chore: specify min node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "keywords": [],
   "author": "Patricia Garcia <pat@patriciagarcia.me>",
   "license": "Apache 2.0",
+  "engines": {
+    "node": ">=5"
+  },
   "dependencies": {
     "angular": "^1.5.5"
   },


### PR DESCRIPTION
Surprisingly, rollup throws the following using Node v4:

```
> rollup -c

{ [Error: Cannot find module 'babel-preset-es2015'] code: 'MODULE_NOT_FOUND' }
Error loading /Users/tom/Projects/client/field/angular-nav-thresholds/src/index.js: Cannot find module 'es2015'
Error: Error loading /Users/tom/Projects/client/field/angular-nav-thresholds/src/index.js: Cannot find module 'es2015'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.require.resolve (internal/module.js:27:19)
    at module.exports (/Users/tom/Projects/client/field/angular-nav-thresholds/node_modules/babel-preset-es2015-rollup/node_modules/modify-babel-preset/index.js:76:21)
    at Object.<anonymous> (/Users/tom/Projects/client/field/angular-nav-thresholds/node_modules/babel-preset-es2015-rollup/index.js:3:18)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:20:19)
```

Same thing works in Node >=5 and since we're testing with v5.x in Travis, give a hint to say so.
