### PR TITLE
Use versioned target population

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": [
-    "es2015-rollup"
+    ["es2015", { "modules": false }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "angular-mocks": "^1.5.5",
     "babel-core": "^6.8.0",
-    "babel-preset-es2015-rollup": "^1.1.1",
+    "babel-preset-es2015": "^6.18.0",
     "ghooks": "^1.3.2",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",

--- a/src/thresholds.service.js
+++ b/src/thresholds.service.js
@@ -48,12 +48,12 @@ const getFactors = (stockCount, location, options) => {
     return {}
   }
 
-  if (!(location.targetPopulation && location.targetPopulation.length)) {
+  if (!(location.targetPopulations && location.targetPopulations.length)) {
     return {}
   }
   const allocationsVersion = getFactorVersion(stockCount, 'allocations', options)
   const plansVersion = getFactorVersion(stockCount, 'plans', options)
-  const targetPopulationVersion = getFactorVersion(stockCount, 'targetPopulation', options)
+  const targetPopulationVersion = getFactorVersion(stockCount, 'targetPopulations', options)
 
   if (typeof allocationsVersion === 'undefined' ||
     typeof plansVersion === 'undefined' ||
@@ -62,8 +62,8 @@ const getFactors = (stockCount, location, options) => {
     return {}
   }
 
-  const allocation = getFactor(location, location.allocations, allocationsVersion)
-  const targetPopulation = getFactor(location, location.targetPopulation, targetPopulationVersion)
+  const allocations = getFactor(location, location.allocations, allocationsVersion)
+  const targetPopulations = getFactor(location, location.targetPopulations, targetPopulationVersion)
 
   let plans = zonePlans
   if (location.level !== 'zone') {
@@ -71,9 +71,9 @@ const getFactors = (stockCount, location, options) => {
   }
 
   return {
-    weeklyLevels: allocation && allocation.weeklyLevels,
+    weeklyLevels: allocations && allocations.weeklyLevels,
     weeksOfStock: plans && plans.weeksOfStock,
-    targetPopulation: targetPopulation && targetPopulation.targetPopulation
+    targetPopulations: targetPopulations && targetPopulations.monthlyTargetPopulations
   }
 }
 
@@ -101,9 +101,9 @@ class ThresholdsService {
       return
     }
 
-    const { weeklyLevels, weeksOfStock, targetPopulation } = getFactors(stockCount, location, options)
+    const { weeklyLevels, weeksOfStock, targetPopulations } = getFactors(stockCount, location, options)
 
-    if (!(weeklyLevels && weeksOfStock && targetPopulation)) {
+    if (!(weeklyLevels && weeksOfStock && targetPopulations)) {
       return
     }
 
@@ -130,7 +130,7 @@ class ThresholdsService {
         return productThresholds
       }, {})
 
-      index[productId].targetPopulation = targetPopulation[productId]
+      index[productId].targetPopulation = targetPopulations[productId]
 
       return index
     }, {})
@@ -155,8 +155,12 @@ class ThresholdsService {
       const id = this.smartId.idify(scLocation, locationIdPattern)
       const allocations = stockCount.allocations || { version: 1 }
       const plans = stockCount.plans || { version: 1 }
-      const targetPopulation = stockCount.targetPopulation || { version: 1 }
-      index[id] = angular.merge({}, { allocations: allocations, plans: plans, targetPopulation: targetPopulation })
+      const targetPopulations = stockCount.targetPopulations || { version: 1 }
+      index[id] = angular.merge({}, {
+        allocations,
+        plans,
+        targetPopulations
+      })
 
       if (scLocation.lga) {
         if (!promises.lga) {

--- a/src/thresholds.service.js
+++ b/src/thresholds.service.js
@@ -25,9 +25,10 @@ const getFactorVersion = (stockCount, factor, options) => {
   if (options.version === 'last') {
     return options.version
   }
-  if (stockCount[factor]) {
-    return stockCount[factor].version
+  if (!(stockCount[factor] && stockCount[factor].version)) {
+    return 1
   }
+  return stockCount[factor].version
 }
 
 const getFactor = (location, versions, version) => {

--- a/test/thresholds.service.spec.js
+++ b/test/thresholds.service.spec.js
@@ -47,17 +47,17 @@ describe('thresholds service', function () {
         }
       }
     ],
-    targetPopulation: [
+    targetPopulations: [
       {
         version: 1,
-        targetPopulation: {
+        monthlyTargetPopulations: {
           'product:a': 500,
           'product:b': 1000
         }
       },
       {
         version: 2,
-        targetPopulation: {
+        monthlyTargetPopulations: {
           'product:a': 1000,
           'product:b': 2000
         }
@@ -86,7 +86,7 @@ describe('thresholds service', function () {
   var stockCount = {
     allocations: { version: 2 },
     plans: { version: 1 },
-    targetPopulation: { version: 2 }
+    targetPopulations: { version: 2 }
   }
 
   var products = [
@@ -228,7 +228,7 @@ describe('thresholds service', function () {
     it('takes an array of objects with location, allocations and plans fields and returns an object of location thresholds', function (done) {
       var stockCounts = [
         // { location: { zone: 'nc' }, allocations: { version: 2 }, plans: { version: 1 } },
-        { location: { zone: 'nc', state: 'kogi' }, allocations: { version: 2 }, plans: { version: 1 }, targetPopulation: { version: 2 } },
+        { location: { zone: 'nc', state: 'kogi' }, allocations: { version: 2 }, plans: { version: 1 }, targetPopulations: { version: 2 } },
         { location: { zone: 'nc', state: 'kogi', lga: 'adavi' } }
       ]
       var expected = {
@@ -241,7 +241,7 @@ describe('thresholds service', function () {
         'zone:nc:state:kogi': {
           allocations: { version: 2 },
           plans: { version: 1 },
-          targetPopulation: { version: 2 },
+          targetPopulations: { version: 2 },
           thresholds: {
             'product:a': { min: 100, reOrder: 200, max: 500, targetPopulation: 1000 },
             'product:b': { min: 200, reOrder: 400, max: 1000, targetPopulation: 2000 }
@@ -250,7 +250,7 @@ describe('thresholds service', function () {
         'zone:nc:state:kogi:lga:adavi': {
           allocations: { version: 1 },
           plans: { version: 1 },
-          targetPopulation: { version: 1 },
+          targetPopulations: { version: 1 },
           thresholds: {
             'product:a': { min: 50, reOrder: 100, max: 250, targetPopulation: 500 },
             'product:b': { min: 100, reOrder: 200, max: 500, targetPopulation: 1000 }

--- a/test/thresholds.service.spec.js
+++ b/test/thresholds.service.spec.js
@@ -186,7 +186,7 @@ describe('thresholds service', function () {
       var actual = thresholdsService.calculateThresholds(unroundedLocation, stockCount, products)
       expect(actual).toEqual(expected)
     })
-    it('uses the last version of plans and allocations if { version: "last"} is passed as option', function () {
+    it('uses the last version of all factors if { version: "last"} is passed as option', function () {
       var expected = {
         'product:a': {
           min: 200,
@@ -202,6 +202,24 @@ describe('thresholds service', function () {
         }
       }
       var actual = thresholdsService.calculateThresholds(location, stockCount, products, null, { version: 'last' })
+      expect(actual).toEqual(expected)
+    })
+    it('uses 1 as default version for all factors if no version is provided', function () {
+      var expected = {
+        'product:a': {
+          min: 50,
+          reOrder: 100,
+          max: 250,
+          targetPopulation: 500
+        },
+        'product:b': {
+          min: 100,
+          reOrder: 200,
+          max: 500,
+          targetPopulation: 1000
+        }
+      }
+      var actual = thresholdsService.calculateThresholds(location, {}, products)
       expect(actual).toEqual(expected)
     })
   })

--- a/test/thresholds.service.spec.js
+++ b/test/thresholds.service.spec.js
@@ -47,10 +47,22 @@ describe('thresholds service', function () {
         }
       }
     ],
-    targetPopulation: {
-      'product:a': 1000,
-      'product:b': 2000
-    },
+    targetPopulation: [
+      {
+        version: 1,
+        targetPopulation: {
+          'product:a': 500,
+          'product:b': 1000
+        }
+      },
+      {
+        version: 2,
+        targetPopulation: {
+          'product:a': 1000,
+          'product:b': 2000
+        }
+      }
+    ],
     plans: [
       {
         version: 1,
@@ -73,14 +85,9 @@ describe('thresholds service', function () {
 
   var stockCount = {
     allocations: { version: 2 },
-    plans: { version: 1 }
+    plans: { version: 1 },
+    targetPopulation: { version: 2 }
   }
-
-  var stockCounts = [
-    // { location: { zone: 'nc' }, allocations: { version: 2 }, plans: { version: 1 } },
-    { location: { zone: 'nc', state: 'kogi' }, allocations: { version: 2 }, plans: { version: 1 } },
-    { location: { zone: 'nc', state: 'kogi', lga: 'adavi' } }
-  ]
 
   var products = [
     // TODO: presentation should be ints
@@ -201,6 +208,11 @@ describe('thresholds service', function () {
 
   describe('getThresholdsFor', function () {
     it('takes an array of objects with location, allocations and plans fields and returns an object of location thresholds', function (done) {
+      var stockCounts = [
+        // { location: { zone: 'nc' }, allocations: { version: 2 }, plans: { version: 1 } },
+        { location: { zone: 'nc', state: 'kogi' }, allocations: { version: 2 }, plans: { version: 1 }, targetPopulation: { version: 2 } },
+        { location: { zone: 'nc', state: 'kogi', lga: 'adavi' } }
+      ]
       var expected = {
         // 'zone:nc': {
           // thresholds: {
@@ -211,6 +223,7 @@ describe('thresholds service', function () {
         'zone:nc:state:kogi': {
           allocations: { version: 2 },
           plans: { version: 1 },
+          targetPopulation: { version: 2 },
           thresholds: {
             'product:a': { min: 100, reOrder: 200, max: 500, targetPopulation: 1000 },
             'product:b': { min: 200, reOrder: 400, max: 1000, targetPopulation: 2000 }
@@ -219,9 +232,10 @@ describe('thresholds service', function () {
         'zone:nc:state:kogi:lga:adavi': {
           allocations: { version: 1 },
           plans: { version: 1 },
+          targetPopulation: { version: 1 },
           thresholds: {
-            'product:a': { min: 50, reOrder: 100, max: 250, targetPopulation: 1000 },
-            'product:b': { min: 100, reOrder: 200, max: 500, targetPopulation: 2000 }
+            'product:a': { min: 50, reOrder: 100, max: 250, targetPopulation: 500 },
+            'product:b': { min: 100, reOrder: 200, max: 500, targetPopulation: 1000 }
           }
         }
       }

--- a/test/thresholds.service.spec.js
+++ b/test/thresholds.service.spec.js
@@ -222,6 +222,30 @@ describe('thresholds service', function () {
       var actual = thresholdsService.calculateThresholds(location, {}, products)
       expect(actual).toEqual(expected)
     })
+    it('still works if the location doc contains a non versioned targetPopulation field', function () {
+      var oldStyleTargetPopulations = {
+        'product:a': 500,
+        'product:b': 1000
+      }
+      var oldStyleLocation = angular.extend({}, location, { targetPopulation: oldStyleTargetPopulations })
+      delete oldStyleLocation.targetPopulations
+      var expected = {
+        'product:a': {
+          min: 50,
+          reOrder: 100,
+          max: 250,
+          targetPopulation: 500
+        },
+        'product:b': {
+          min: 100,
+          reOrder: 200,
+          max: 500,
+          targetPopulation: 1000
+        }
+      }
+      var actual = thresholdsService.calculateThresholds(oldStyleLocation, {}, products)
+      expect(actual).toEqual(expected)
+    })
   })
 
   describe('getThresholdsFor', function () {


### PR DESCRIPTION
Connects #20 

- Updates the service to use the new versioned target population field
- Makes sure that if no version is provided for any of the factors, version 1 is used by default